### PR TITLE
fix: add AccentColor to asset catalog

### DIFF
--- a/Projects/App/Resources/Images/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Images/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.980",
+          "green" : "0.502",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Resolves the Xcode warning "Accent color 'AccentColor' is not present in any asset catalogs" by adding an AccentColor.colorset to the asset catalog.

Fixes #116

Generated with [Claude Code](https://claude.ai/code)