### PR TITLE
fix: replace deprecated SKStoreReviewController with AppStore.requestReview(in:)

### DIFF
--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -88,7 +88,9 @@ struct WhereWeGoApp: App {
                 WWGDefaults.increaseLaunchCount();
                 isLaunched = true;
                 if WWGDefaults.LaunchCount > 0 && WWGDefaults.LaunchCount % 90 == 0 {
-                    SKStoreReviewController.requestReview();
+                    if let scene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+                        AppStore.requestReview(in: scene);
+                    }
                 }
             }
 


### PR DESCRIPTION
Replaces `SKStoreReviewController.requestReview()` (deprecated in iOS 14/18) with `AppStore.requestReview(in:)` using the active `UIWindowScene`.

Closes #118

Generated with [Claude Code](https://claude.ai/code)