### PR TITLE
feat: enable Renovate cron schedule

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,9 +1,8 @@
 name: Renovate
 
 on:
-  # Disabled until tested — uncomment after confirming the workflow runs correctly
-  # schedule:
-  #   - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC (before 9am KST)
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC (09:00 KST)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Enables the weekly cron schedule for the Renovate workflow (was commented out pending test)
- Runs every Monday at 00:00 UTC (09:00 KST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)