### PR TITLE
fix: locate Crashlytics/run dynamically for Tuist registry layout

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -127,3 +127,8 @@ language_backend:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:

--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -60,7 +60,7 @@ let project = Project(
                             name: "Merge SKAdNetworkItems",
                             inputPaths: ["$(SRCROOT)/Resources/InfoPlist/skNetworks.plist"],
                             outputPaths: []),
-                      .post(script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",
+                      .post(script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages\" -name run -path \"*/Crashlytics/run\" | head -1); \"$CRASHLYTICS_RUN\"",
                             name: "Upload dSYM for Crashlytics",
                             inputPaths: ["${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
                                          "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",


### PR DESCRIPTION
## Summary
- Replaces hardcoded `SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run` path with a dynamic `find` command
- Fixes archive failure after migrating Firebase to Tuist registry (`firebase.firebase-ios-sdk`)
- Registry unpacks under `SourcePackages/registry/downloads/firebase/firebase-ios-sdk/{version}/` — version directory changes on every update

## Root Cause
```
# Old (broken after registry migration)
${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run

# New (works for both checkouts/ and registry/)
CRASHLYTICS_RUN=$(find "${BUILD_DIR%/Build/*}/SourcePackages" -name run -path "*/Crashlytics/run" | head -1); "$CRASHLYTICS_RUN"
```

## Test Plan
- [ ] Archive build succeeds (Upload dSYM for Crashlytics phase runs without path error)
- [ ] dSYM upload reaches Firebase Crashlytics dashboard