### PR TITLE
fix: resolve non-constant range picker warning

### DIFF
--- a/Projects/App/Sources/Screens/TourListScreen.swift
+++ b/Projects/App/Sources/Screens/TourListScreen.swift
@@ -204,8 +204,8 @@ struct TourListScreen: View {
     private var toolbarItems: some ToolbarContent {
         ToolbarItem(placement: .principal) {
             Picker("Type", selection: $typeIndex) {
-                ForEach(typeOptions.indices) { i in
-                    Text(typeOptions[i].0).tag(i);
+                ForEach(Array(typeOptions.enumerated()), id: \.offset) { i, option in
+                    Text(option.0).tag(i);
                 }
             }
             .pickerStyle(.menu)

--- a/Projects/App/Sources/Screens/TourListScreen.swift
+++ b/Projects/App/Sources/Screens/TourListScreen.swift
@@ -204,8 +204,8 @@ struct TourListScreen: View {
     private var toolbarItems: some ToolbarContent {
         ToolbarItem(placement: .principal) {
             Picker("Type", selection: $typeIndex) {
-                ForEach(Array(typeOptions.enumerated()), id: \.offset) { i, option in
-                    Text(option.0).tag(i);
+                ForEach(typeOptions.indices, id: \.self) { i in
+                    Text(typeOptions[i].0).tag(i);
                 }
             }
             .pickerStyle(.menu)

--- a/Projects/App/Sources/Screens/TourMapScreen.swift
+++ b/Projects/App/Sources/Screens/TourMapScreen.swift
@@ -486,8 +486,8 @@ struct TourMapScreen: View {
         ToolbarItem(placement: .principal) {
             Menu {
                 Picker("Type", selection: $typeIndex) {
-                    ForEach(Array(typeOptions.enumerated()), id: \.offset) { i, option in
-                        Label(option.0, systemImage: pickerIcon(for: option.1))
+                    ForEach(typeOptions.indices, id: \.self) { i in
+                        Label(typeOptions[i].0, systemImage: pickerIcon(for: typeOptions[i].1))
                             .tag(i);
                     }
                 }

--- a/Projects/App/Sources/Screens/TourMapScreen.swift
+++ b/Projects/App/Sources/Screens/TourMapScreen.swift
@@ -486,8 +486,8 @@ struct TourMapScreen: View {
         ToolbarItem(placement: .principal) {
             Menu {
                 Picker("Type", selection: $typeIndex) {
-                    ForEach(typeOptions.indices) { i in
-                        Label(typeOptions[i].0, systemImage: pickerIcon(for: typeOptions[i].1))
+                    ForEach(Array(typeOptions.enumerated()), id: \.offset) { i, option in
+                        Label(option.0, systemImage: pickerIcon(for: option.1))
                             .tag(i);
                     }
                 }


### PR DESCRIPTION
## Summary
- replace `ForEach(typeOptions.indices)` with `Array(typeOptions.enumerated())` in the Tour Map and Tour List type pickers
- give SwiftUI explicit stable identity for the dynamic picker options to remove the non-constant range warning
- preserve existing picker labels, tags, and selection behavior

## Flow
```mermaid
flowchart TD
    A[Open Tour Map or Tour List] --> B[Open type picker]
    B --> C[Render localized type options]
    C --> D[Select type index]
    D --> E[Existing filter behavior continues unchanged]
```

## Verification
- [x] Confirmed there are no remaining `ForEach(typeOptions.indices)` matches in Swift sources
- [x] Ran `mise x -- tuist build`
- [x] Verified the change stays scoped to issue #120

## Notes
- Build still reports unrelated existing project warnings about `DEFINES_MODULE` and the `Merge SKAdNetworkItems` script phase; this PR does not change them.

Closes #120