### PR TITLE
fix: resolve Crashlytics run script path

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -60,7 +60,28 @@ let project = Project(
                             name: "Merge SKAdNetworkItems",
                             inputPaths: ["$(SRCROOT)/Resources/InfoPlist/skNetworks.plist"],
                             outputPaths: []),
-                      .post(script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages\" -name run -path \"*/Crashlytics/run\" | head -1); \"$CRASHLYTICS_RUN\"",
+                      .post(script: """
+                    SOURCE_PACKAGES_ROOT="${SOURCE_PACKAGES_DIR_PATH:-${BUILD_DIR%/Build/*}/SourcePackages}"
+                    CRASHLYTICS_RUN_SCRIPT=""
+
+                    for candidate in \
+                      "$SOURCE_PACKAGES_ROOT/checkouts/firebase-ios-sdk/Crashlytics/run" \
+                      "$SOURCE_PACKAGES_ROOT/registry/downloads/firebase/firebase-ios-sdk/Crashlytics/run" \
+                      "$SOURCE_PACKAGES_ROOT"/registry/downloads/firebase/firebase-ios-sdk/*/Crashlytics/run
+                    do
+                      if [ -f "$candidate" ]; then
+                        CRASHLYTICS_RUN_SCRIPT="$candidate"
+                        break
+                      fi
+                    done
+
+                    if [ -z "$CRASHLYTICS_RUN_SCRIPT" ]; then
+                      echo "error: Firebase Crashlytics run script not found under $SOURCE_PACKAGES_ROOT"
+                      exit 1
+                    fi
+
+                    "$CRASHLYTICS_RUN_SCRIPT"
+                    """,
                             name: "Upload dSYM for Crashlytics",
                             inputPaths: ["${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
                                          "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",


### PR DESCRIPTION
## Goal and success criteria
- prevent Firebase/Crashlytics package layout changes from breaking install/archive uploads
- resolve the Crashlytics `run` script from current checkout and registry layouts

## Summary
- replace the generic `find ... | head -1` lookup with explicit SourcePackages path resolution
- prefer `SOURCE_PACKAGES_DIR_PATH` when Xcode provides it, with the existing DerivedData fallback
- check Firebase checkout, registry direct, and registry versioned Crashlytics script locations before failing with a clear error

## Flow
```mermaid
flowchart TD
    A[Install or archive build] --> B[Resolve SourcePackages root]
    B --> C{Crashlytics run script found?}
    C -->|checkout layout| D[Execute Crashlytics upload script]
    C -->|registry layout| D
    C -->|not found| E[Emit clear build error]
```

## Verification
- [x] Updated the Tuist-managed Crashlytics post-build script in `Projects/App/Project.swift`
- [x] Confirmed the script now checks multiple Firebase package layouts
- [ ] `mise x -- tuist build` currently fails in an unrelated `Push build insights` step after app linking; the Crashlytics path change itself is in place

## Risk
- Low: scoped to the Crashlytics dSYM upload script only