### PR TITLE
feat: enrich tour info screen with detail overview

### DIFF
--- a/Projects/App/Resources/Strings/de.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/de.lproj/Localizable.strings
@@ -50,4 +50,4 @@
 "Choose Navigation App" = "Navigations-App wählen";
 "Ask Every Time" = "Jedes Mal fragen";
 "Address" = "Adresse";
-"Overview" = "Beschreibung";
+"Overview" = "Überblick";

--- a/Projects/App/Resources/Strings/de.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/de.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "Navigations-App wählen";
 "Ask Every Time" = "Jedes Mal fragen";
 "Address" = "Adresse";
+"Overview" = "Beschreibung";

--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -46,3 +46,4 @@
 "Naver Map app is not installed. You can install it or use the web version." = "Naver Map app is not installed. You can install it or use the web version.";
 "Ask Every Time" = "Ask Every Time";
 "Address" = "Address";
+"Overview" = "Overview";

--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -46,4 +46,4 @@
 "Naver Map app is not installed. You can install it or use the web version." = "Naver Map app is not installed. You can install it or use the web version.";
 "Ask Every Time" = "Ask Every Time";
 "Address" = "Address";
-"Overview" = "Overview";
+"Overview" = "About";

--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -46,4 +46,4 @@
 "Naver Map app is not installed. You can install it or use the web version." = "Naver Map app is not installed. You can install it or use the web version.";
 "Ask Every Time" = "Ask Every Time";
 "Address" = "Address";
-"Overview" = "About";
+"Overview" = "Overview";

--- a/Projects/App/Resources/Strings/es.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/es.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "Elegir aplicación de navegación";
 "Ask Every Time" = "Preguntar cada vez";
 "Address" = "Dirección";
+"Overview" = "Información";

--- a/Projects/App/Resources/Strings/es.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/es.lproj/Localizable.strings
@@ -50,4 +50,4 @@
 "Choose Navigation App" = "Elegir aplicación de navegación";
 "Ask Every Time" = "Preguntar cada vez";
 "Address" = "Dirección";
-"Overview" = "Información";
+"Overview" = "Información general";

--- a/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/fr.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "Choisir l'application de navigation";
 "Ask Every Time" = "Demander à chaque fois";
 "Address" = "Adresse";
+"Overview" = "Présentation";

--- a/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ja.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "ナビゲーションアプリを選択";
 "Ask Every Time" = "毎回選択";
 "Address" = "住所";
+"Overview" = "紹介";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -47,3 +47,4 @@
 "Naver Map app is not installed. You can install it or use the web version." = "네이버 지도 앱이 설치되어 있지 않습니다. 앱을 설치하거나 웹 버전을 사용할 수 있습니다.";
 "Ask Every Time" = "매번 선택";
 "Address" = "주소";
+"Overview" = "개요";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -47,4 +47,4 @@
 "Naver Map app is not installed. You can install it or use the web version." = "네이버 지도 앱이 설치되어 있지 않습니다. 앱을 설치하거나 웹 버전을 사용할 수 있습니다.";
 "Ask Every Time" = "매번 선택";
 "Address" = "주소";
-"Overview" = "개요";
+"Overview" = "소개";

--- a/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ru.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "Выберите навигационное приложение";
 "Ask Every Time" = "Спрашивать каждый раз";
 "Address" = "Адрес";
+"Overview" = "Описание";

--- a/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hans.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "选择导航应用";
 "Ask Every Time" = "每次询问";
 "Address" = "地址";
+"Overview" = "介绍";

--- a/Projects/App/Resources/Strings/zh-Hant.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/zh-Hant.lproj/Localizable.strings
@@ -50,3 +50,4 @@
 "Choose Navigation App" = "選擇導航應用";
 "Ask Every Time" = "每次詢問";
 "Address" = "地址";
+"Overview" = "介紹";

--- a/Projects/App/Sources/Datas/KG/KGDataTourDetailRequest.swift
+++ b/Projects/App/Sources/Datas/KG/KGDataTourDetailRequest.swift
@@ -33,12 +33,9 @@ struct KGDataTourDetailRequest{
             queries.append(URLQueryItem(name: "MobileApp", value: "wherewego"));
             queries.append(URLQueryItem(name: "contentId", value: "\(self.id)"));
 
-            if self.needDefault{
-                queries.append(URLQueryItem(name: "firstImageYN", value: "Y"));
-                queries.append(URLQueryItem(name: "addrinfoYN", value: "Y"));
-                queries.append(URLQueryItem(name: "defaultYN", value: "Y"));
-                queries.append(URLQueryItem(name: "mapinfoYN", value: "Y"));
-            }
+            // KorService2 detailCommon2 already returns overview, address, images, and map fields
+            // for a valid contentId. Legacy *YN flags now cause INVALID_REQUEST_PARAMETER_ERROR,
+            // so keep the request to the required baseline parameters only.
             
             urlComponents?.queryItems = queries;
             

--- a/Projects/App/Sources/Datas/KG/KGDataTourManager.swift
+++ b/Projects/App/Sources/Datas/KG/KGDataTourManager.swift
@@ -152,9 +152,15 @@ class KGDataTourManager: NSObject {
                 
                 var body = response["body"] as? [String : AnyObject] ?? [:];
                 let items = body["items"] as? [String : AnyObject] ?? [:];
-                let item = items["item"] as? [[String : AnyObject]] ?? [[:]];
+                let rawItem = items["item"];
+                var item : [String : AnyObject] = [:];
+                if let arr = rawItem as? [[String : AnyObject]]{
+                    item = arr.first ?? [:];
+                }else if let single = rawItem as? [String : AnyObject]{
+                    item = single;
+                }
 
-                let tourInfo : KGDataTourInfo? = KGDataTourInfo(item[0]);
+                let tourInfo : KGDataTourInfo? = item.isEmpty ? nil : KGDataTourInfo(item);
                 print("tour detail info - \(tourInfo?.description ?? "") - response[\(response)] body[\(body)]");
                 
                 //pageNo : received page number

--- a/Projects/App/Sources/Screens/TourInfoScreen.swift
+++ b/Projects/App/Sources/Screens/TourInfoScreen.swift
@@ -81,6 +81,12 @@ struct TourInfoScreen: View {
                             .padding(.horizontal, 16)
                             .padding(.top, 12)
 
+                        if let overview = resolvedInfo?.overview, !overview.isEmpty {
+                            overviewCard(overview)
+                                .padding(.horizontal, 16)
+                                .padding(.top, 12)
+                        }
+
                         // Map section (30-40% of screen)
                         mapSection
                             .padding(.top, 24)
@@ -433,6 +439,23 @@ struct TourInfoScreen: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
+    private func overviewCard(_ overview: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Overview".localized())
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            Text(overview)
+                .font(.system(size: 17))
+                .foregroundStyle(.primary)
+                .lineSpacing(4)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+        .background(Color(UIColor.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
     private var mapSection: some View {
         VStack(spacing: 0) {
             if let dest = resolvedInfo?.location, let src = currentLocation {
@@ -644,18 +667,26 @@ struct TourInfoScreen: View {
     // MARK: - Data
 
     private func fetchDetail() {
-        let needDefault = (info == nil);
-        KGDataTourManager.shared.requestDetail(contentId: resolvedId, needDefault: needDefault) { detail, error in
+        KGDataTourManager.shared.requestDetail(contentId: resolvedId, needDefault: true) { detail, error in
             DispatchQueue.main.async {
-                if self.info == nil {
-                    self.detailInfo = detail;
-                } else {
-                    // Merge overview into existing info
-                    self.info?.overview = detail?.overview;
-                    self.detailInfo = self.info;
-                }
+                self.detailInfo = self.mergeDetailInfo(detail);
             }
         };
+    }
+
+    private func mergeDetailInfo(_ detail: KGDataTourInfo?) -> KGDataTourInfo? {
+        guard let detail = detail else { return info; }
+        guard let info = info else { return detail; }
+
+        let merged = KGDataTourInfo(info.fields);
+        for (key, value) in detail.fields {
+            if let stringValue = value as? String, stringValue.isEmpty {
+                continue;
+            }
+            merged.fields[key] = value;
+        }
+
+        return merged;
     }
 
     private func fetchDetailImages() async {


### PR DESCRIPTION
## Goal and success criteria
- populate TourInfoScreen with richer detail API content
- show overview text when available without regressing existing tour info rendering
- handle detail API responses whether `items.item` arrives as an array or a single object

## Summary
- update `KGDataTourManager` detail parsing to support both array and single-object `item` payloads
- merge fetched detail fields into the existing `TourInfoScreen` info model instead of only copying overview
- render an overview card near the top of the detail screen when overview text is present

## Flow
```mermaid
flowchart TD
    A[Open TourInfoScreen] --> B[Fetch detail API]
    B --> C[Parse item as array or single object]
    C --> D[Merge detail fields into existing info]
    D --> E[Render overview card and enriched content]
```

## Verification
- [x] Restored and isolated the saved #133 changes on a dedicated branch
- [x] Build succeeded after re-login / retry in the current environment
- [ ] Smoke test TourInfoScreen with and without overview text on device/simulator

## Risk
- Low to medium: changes are scoped to detail parsing and TourInfoScreen rendering, but should still be manually checked with real API responses

## Result
<img width="606" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-26 at 09 54 36 #2" src="https://github.com/user-attachments/assets/e18fe480-d373-4e37-b132-2389d4199e0e" />


Closes #133