### PR TITLE
improve: automate release submission flow

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -57,15 +57,23 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          tuist install
+          mise x -- tuist install
 
       - name: Log in Tuist
         run: |
-          tuist auth login
+          mise x -- tuist auth login
+
+      - name: Set up Tuist Cache
+        run: |
+          mise x -- tuist setup cache
+
+      - name: Setup Tuist Registry
+        run: |
+          mise x -- tuist registry setup
 
       - name: Generate Xcode Project
         run: |
-          tuist generate --cache-profile none    
+          mise x -- tuist generate --cache-profile none
 
       - name: Import signing certificate
         env:
@@ -149,7 +157,7 @@ jobs:
           echo "ARCHIVE_PATH: $ARCHIVE_PATH"
 
           # Build archive
-          tuist xcodebuild archive \
+          mise x -- tuist xcodebuild archive \
             -workspace $WORKSPACE \
             -scheme "$SCHEME" \
             -configuration Release \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,7 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+ENV['ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD'] = "false"
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 platform :ios do
@@ -122,9 +123,11 @@ platform :ios do
         upload_to_app_store(
           ipa: @ipa_path,
           api_key_path: @api_key_path,
-          release_notes: changelog,
           app_identifier: @package_name,
           submit_for_review: true,
+          force: true,
+          skip_screenshots: true,
+          run_precheck_before_submit: false,
         )
         puts "iOS 심사 제출 완료"
     else


### PR DESCRIPTION
## Goal and success criteria
- make the iOS deploy workflow compatible with the current Tuist registry/cache setup
- let Fastlane submit App Store releases automatically without manual screenshot/precheck blockers
- keep the change limited to deployment automation, not app code

## Summary
- update the deploy workflow to run Tuist through `mise`, then set up Tuist cache and registry before project generation/archive
- keep archive generation aligned with repo tooling by using `mise x -- tuist xcodebuild archive`
- mirror the TalkTrans release submission behavior in Fastlane by forcing `upload_to_app_store`, skipping screenshots, and disabling precheck before auto submission

## Flow
```mermaid
flowchart TD
    A[Manual deploy workflow dispatch] --> B[mise x -- tuist install/auth]
    B --> C[tuist setup cache + registry]
    C --> D[Generate and archive app]
    D --> E[Export IPA]
    E --> F{isReleasing?}
    F -->|false| G[Upload to TestFlight]
    F -->|true| H[Upload to App Store and submit automatically]
```

## Verification
- [x] `ruby -c fastlane/Fastfile`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-ios.yml")'`
- [x] Reviewed diff against the TalkTrans reference workflow/Fastfile behavior

## Risk
- Medium: this changes release automation behavior, so the next release run should be monitored closely for App Store Connect submission responses