### PR TITLE
ci: upgrade Xcode to 26.5

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Import Secret Key
         run: |


### PR DESCRIPTION
## Summary
- Bump deploy-ios.yml `xcode-select` target from Xcode_26.1.1.app to Xcode_26.5.app

## Test plan
- [ ] Trigger workflow_dispatch, confirm build/archive succeeds on Xcode 26.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)