### PR TITLE
build: upgrade firebase-ios-sdk to 12.17.0

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -3,7 +3,7 @@ import ProjectDescription
 let project = Project(
     name: "DynamicThirdParty",
     packages: [.package(id: "SDWebImage.SDWebImage", from: "5.21.7"),
-               .package(id: "firebase.firebase-ios-sdk", from: "12.12.1"),
+               .package(id: "firebase.firebase-ios-sdk", from: "12.17.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Bump firebase.firebase-ios-sdk pin in Projects/DynamicThirdParty/Project.swift from 12.12.1 to 12.17.0 (latest)

## Test plan
- [x] tuist install resolves SPM deps cleanly
- [x] tuist build succeeds locally (App scheme, iphonesimulator)
- [x] CI deploy-ios.yml run against this branch: Build and Archive App + Export IPA both succeeded on Xcode 26.5
- [x] Checked against a similar Firebase 12.17.0 upgrade in 2sem/WhoCallMe#62 which hit a duplicate google.googleappmeasurement package identity + APM* linker symbol issue -- wherewego does not have that duplicate declaration and the CI archive/export already passed, so this repo is not affected
- Upload to TestFlight failed in that CI run only because CFBundleShortVersionString (2.2.1) matches the already-approved App Store version -- expected, unrelated to this change, requires an a.b.c release branch version bump to actually upload

Generated with Claude Code
