### PR TITLE
fix: pin DynamicThirdParty and ThirdParty deployment targets to iOS 18.0

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -11,6 +11,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: "com.y2k.wherewego.thirdparty.dynamic",
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "SDWebImage", type: .runtime),
                            .package(product: "FirebaseCrashlytics", type: .runtime),
                            .package(product: "FirebaseAnalytics", type: .runtime),

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -20,6 +20,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: "com.y2k.wherewego.thirdparty",
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "KakaoSDK", type: .runtime),
                            .package(product: "MBProgressHUD", type: .runtime),
                            .package(product: "LSExtensions", type: .runtime),


### PR DESCRIPTION
## Summary
- Closes #121: build warning "ld: building for iOS-simulator-18.0, but linking with dylib built for newer version 26.2"
- Root cause: App's target pins deploymentTargets to iOS 18.0, but DynamicThirdParty and ThirdParty targets had no deploymentTargets set, so they fell back to a higher default
- Add deploymentTargets: .iOS("18.0") to both DynamicThirdParty and ThirdParty targets to match App

## Test plan
- [x] tuist install resolves cleanly
- [x] tuist build succeeds for App, DynamicThirdParty, ThirdParty schemes
- [x] Grepped full build log for "newer version" / "newer OS" / "dylib built for" -- zero matches, warning confirmed gone

## Note
Found an unrelated pre-existing warning while verifying: `DEFINES_MODULE was set, but no umbrella header could be found to generate the module map` on the ThirdParty target. Not part of this fix, not touched here.

Generated with Claude Code
